### PR TITLE
optimize big size scan reqs

### DIFF
--- a/storage/eloq/ha_eloq.cc
+++ b/storage/eloq/ha_eloq.cc
@@ -4152,6 +4152,7 @@ int ha_eloq::PkIndexScanOpen(const txservice::TxKey *start_key,
   bool require_recs= decode_flag_ > 0;
   bool require_sort= eloq_random_scan_sort ||
                      (active_index != MAX_INDEXES && decode_flag_ > 0);
+  end_specified_= end_key != nullptr;
 
   auto [yield_func, resume_func]= my_tx->CoroFunctors();
 
@@ -4211,6 +4212,7 @@ int ha_eloq::SkIndexScanOpen(const txservice::TxKey *start_index_key,
   bool is_require_keys= has_hidden_pk(table) || decode_flag_ > 0;
   bool is_require_recs= is_require_keys;
   bool is_require_sort= is_require_keys;
+  end_specified_= end_index_key != nullptr;
 
   auto [yield_func, resume_func]= my_tx->CoroFunctors();
 
@@ -5212,7 +5214,7 @@ int ha_eloq::IndexScanClose()
   ccm_scan_key_= nullptr;
   ccm_scan_rec_= nullptr;
   ccm_scan_rec_status_= txservice::RecordStatus::Unknown;
-
+  end_specified_= false;
   scan_batch_idx_= UINT64_MAX;
   if (scan_batch_.size() > DEFAULT_SCAN_TUPLE_SIZE)
   {

--- a/storage/eloq/ha_eloq.h
+++ b/storage/eloq/ha_eloq.h
@@ -717,6 +717,12 @@ private:
 
   uint32_t PrefetchSize()
   {
+    if (end_specified_)
+    {
+      // Prefetch more agressively if end key is specified as the scan
+      // will not prefetch beyond the end key.
+      return 256;
+    }
     std::array<uint32_t, 5> boundaries= {1, 4, 16, 64, 256};
 
     size_t idx= 0;
@@ -774,6 +780,7 @@ private:
   txservice::TxKey search_tx_key_{&search_key_};
   EloqKey scan_end_key_;
   txservice::TxKey scan_end_tx_key_{&scan_end_key_};
+  bool end_specified_{false};
 
   uint64_t scan_alias_{UINT64_MAX};
   // index currently used if scan is active


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated an internal submodule reference (no functional changes).

* **Bug Fixes / Performance**
  * Range scans now correctly track whether an explicit end boundary was provided and reset that state after scans.
  * When an end boundary is specified, prefetch is forced to a smaller fixed value to stabilize performance near scan limits.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->