### PR TITLE
Add engine type prefix to kv_table_name

### DIFF
--- a/storage/eloq/eloq_db.cpp
+++ b/storage/eloq/eloq_db.cpp
@@ -396,7 +396,8 @@ int eloq_create_database(THD *thd, LEX_CSTRING db,
   }
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
-  bool ok= storage_hd->UpsertDatabase(key, {opt_binary.str, opt_binary.length},
+  bool ok= storage_hd->UpsertDatabase(txservice::TableEngine::EloqSql, key,
+                                      {opt_binary.str, opt_binary.length},
                                       yield_func, resume_func);
   if (!ok)
   {
@@ -439,7 +440,8 @@ int eloq_update_database(THD *thd, LEX_CSTRING db,
   }
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
-  bool ok= storage_hd->UpsertDatabase(key, {opt_binary.str, opt_binary.length},
+  bool ok= storage_hd->UpsertDatabase(txservice::TableEngine::EloqSql, key,
+                                      {opt_binary.str, opt_binary.length},
                                       yield_func, resume_func);
   if (!ok)
   {
@@ -464,7 +466,8 @@ int eloq_drop_database(THD *thd, LEX_CSTRING db)
   }
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
-  bool ok= storage_hd->DropDatabase(key, yield_func, resume_func);
+  bool ok= storage_hd->DropDatabase(txservice::TableEngine::EloqSql, key,
+                                    yield_func, resume_func);
   if (!ok)
   {
     my_printf_error(HA_ERR_INTERNAL_ERROR, "Eloq drop database '%s' failed",
@@ -486,8 +489,8 @@ int eloq_exist_database(THD *thd, LEX_CSTRING db, bool &exist)
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
   std::string data;
-  bool ok=
-      storage_hd->FetchDatabase(key, data, exist, yield_func, resume_func);
+  bool ok= storage_hd->FetchDatabase(txservice::TableEngine::EloqSql, key,
+                                     data, exist, yield_func, resume_func);
   if (!ok)
   {
     my_printf_error(HA_ERR_INTERNAL_ERROR, "Eloq fetch database '%s' failed",
@@ -513,8 +516,8 @@ int eloq_discover_database(THD *thd, LEX_CSTRING db,
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
   bool exists= false;
   std::string data;
-  bool ok=
-      storage_hd->FetchDatabase(key, data, exists, yield_func, resume_func);
+  bool ok= storage_hd->FetchDatabase(txservice::TableEngine::EloqSql, key,
+                                     data, exists, yield_func, resume_func);
   if (!ok)
   {
     my_printf_error(HA_ERR_INTERNAL_ERROR, "Eloq fetch database '%s' failed",
@@ -539,7 +542,8 @@ int eloq_discover_database_names(THD *thd,
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
   std::vector<std::string> names;
-  bool ok= storage_hd->FetchAllDatabase(names, yield_func, resume_func);
+  bool ok= storage_hd->FetchAllDatabase(txservice::TableEngine::EloqSql, names,
+                                        yield_func, resume_func);
   if (!ok)
   {
     my_printf_error(HA_ERR_INTERNAL_ERROR, "Eloq fetch all databases failed",
@@ -564,7 +568,8 @@ int eloq_discover_database_names_wild(THD *thd, Discovered_table_list &tl)
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
   std::vector<std::string> names;
-  bool ok= storage_hd->FetchAllDatabase(names, yield_func, resume_func);
+  bool ok= storage_hd->FetchAllDatabase(txservice::TableEngine::EloqSql, names,
+                                        yield_func, resume_func);
   if (!ok)
   {
     my_printf_error(HA_ERR_INTERNAL_ERROR, "Eloq fetch all databases failed",

--- a/storage/eloq/eloq_i_s.cc
+++ b/storage/eloq/eloq_i_s.cc
@@ -64,8 +64,8 @@ static int eloq_i_s_temp_table_info_fill_table(THD *thd, TABLE_LIST *tables,
 
   auto [yield_func, resume_func]= thd_get_coro_functors(thd);
   std::vector<std::string> table_names;
-  bool ok=
-      storage_hd->DiscoverAllTableNames(table_names, yield_func, resume_func);
+  bool ok= storage_hd->DiscoverAllTableNames(
+      txservice::TableEngine::EloqSql, table_names, yield_func, resume_func);
   if (ok)
   {
     for (const std::string &table_name : table_names)

--- a/storage/eloq/ha_eloq.cc
+++ b/storage/eloq/ha_eloq.cc
@@ -821,7 +821,8 @@ static void drop_table(const std::string &table_name_str)
 static void drop_orphan_tmp_tables()
 {
   std::vector<std::string> table_names;
-  if (storage_hd->DiscoverAllTableNames(table_names))
+  if (storage_hd->DiscoverAllTableNames(txservice::TableEngine::EloqSql,
+                                        table_names))
   {
     for (const std::string &table_name_str : table_names)
     {
@@ -1013,7 +1014,8 @@ static int eloq_discover_table_names(handlerton *hton, LEX_CSTRING *db,
     // Discover table names.
     std::vector<std::string> full_name_vec;
     auto [yield_func, resume_func]= thd_get_coro_functors(current_thd);
-    bool ok= storage_hd->DiscoverAllTableNames(full_name_vec, yield_func,
+    bool ok= storage_hd->DiscoverAllTableNames(txservice::TableEngine::EloqSql,
+                                               full_name_vec, yield_func,
                                                resume_func);
     if (!ok)
     {
@@ -6645,8 +6647,8 @@ int ha_eloq::create(const char *name, TABLE *table_arg,
   bool db_exists= false;
 
   auto [yield_func, resume_func]= my_tx->CoroFunctors();
-  if (!storage_hd->FetchDatabase(db, db_opt, db_exists, yield_func,
-                                 resume_func))
+  if (!storage_hd->FetchDatabase(txservice::TableEngine::EloqSql, db, db_opt,
+                                 db_exists, yield_func, resume_func))
   {
     DBUG_RETURN(HA_ERR_ELOQ_CREATE_TABLE_FAILED);
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Storage subsystem now explicitly selects the EloqSql table engine for database and table-discovery operations; runtime behavior and error handling remain unchanged.
  * Internal interfaces updated to propagate the chosen engine across storage calls, improving clarity of engine routing.

* **Chore**
  * Submodule pointer advanced; low-risk internal wiring updates only — no user action required.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->