### PR TITLE
update subm

### DIFF
--- a/concourse/scripts/dss_server.ini
+++ b/concourse/scripts/dss_server.ini
@@ -11,3 +11,5 @@ eloq_store_cloud_endpoint=http://127.0.0.1:9900
 eloq_store_cloud_store_path=dss-eloqsql-mtr-test/eloqstore
 eloq_store_cloud_access_key=XXXXXX
 eloq_store_cloud_secret_key=XXXXXX
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/concourse/scripts/mtr_bootstrap_ds.cnf
+++ b/concourse/scripts/mtr_bootstrap_ds.cnf
@@ -22,3 +22,6 @@ eloq_store_cloud_store_path=dss-eloqsql-mtr-test/eloqstore
 eloq_store_cloud_access_key=XXXXXX
 eloq_store_cloud_secret_key=XXXXXX
 eloq_store_reuse_local_files=true
+
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/concourse/scripts/mtr_multi_bootstrap_ds.cnf
+++ b/concourse/scripts/mtr_multi_bootstrap_ds.cnf
@@ -18,3 +18,6 @@ aws_secret_key=XXXXXX
 eloq_dss_config_file_path=
 eloq_dss_peer_node=localhost:9100
 
+
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/storage/eloq/mysql-test/mono_basic/data_substrate.cnf
+++ b/storage/eloq/mysql-test/mono_basic/data_substrate.cnf
@@ -19,3 +19,5 @@ eloq_store_cloud_store_path=dss-eloqsql-mtr-test/eloqstore
 eloq_store_cloud_access_key=XXXXXX
 eloq_store_cloud_secret_key=XXXXXX
 eloq_store_reuse_local_files=true
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/storage/eloq/mysql-test/mono_main/data_substrate.cnf
+++ b/storage/eloq/mysql-test/mono_main/data_substrate.cnf
@@ -19,3 +19,6 @@ eloq_store_cloud_store_path=dss-eloqsql-mtr-test/eloqstore
 eloq_store_cloud_access_key=XXXXXX
 eloq_store_cloud_secret_key=XXXXXX
 eloq_store_reuse_local_files=true
+
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/storage/eloq/mysql-test/mono_multi/data_substrate1.cnf
+++ b/storage/eloq/mysql-test/mono_multi/data_substrate1.cnf
@@ -17,3 +17,6 @@ aws_secret_key=XXXXXX
 
 eloq_dss_config_file_path=
 eloq_dss_peer_node=127.0.0.1:9100
+
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/storage/eloq/mysql-test/mono_multi/data_substrate2.cnf
+++ b/storage/eloq/mysql-test/mono_multi/data_substrate2.cnf
@@ -17,3 +17,6 @@ aws_secret_key=XXXXXX
 
 eloq_dss_config_file_path=
 eloq_dss_peer_node=127.0.0.1:9100
+
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1

--- a/storage/eloq/mysql-test/mono_multi/data_substrate3.cnf
+++ b/storage/eloq/mysql-test/mono_multi/data_substrate3.cnf
@@ -17,3 +17,6 @@ aws_secret_key=XXXXXX
 
 eloq_dss_config_file_path=
 eloq_dss_peer_node=127.0.0.1:9100
+
+eloq_store_max_concurrent_writes=0
+eloq_store_pages_per_file_shift=1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds two new store tuning parameters to DS/concourse and MySQL test configs.
> 
> - Introduces `eloq_store_max_concurrent_writes=0` and `eloq_store_pages_per_file_shift=1` in `concourse/scripts/*.ini|*.cnf` and `storage/eloq/mysql-test/**/data_substrate*.cnf`
> - No code changes; only config updates affecting write concurrency and page sizing behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb5b954edfcb41b53b551a5275095f89316e53a0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a submodule pointer; no functional changes visible to users.

* **Configuration**
  * Added two new store configuration options across test/storage configs to control max concurrent writes and pages-per-file shift, which may affect storage write concurrency and paging behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->