### PR TITLE
build: use Data Substrate third-party workspace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,27 @@ MESSAGE(STATUS "Running cmake version ${CMAKE_VERSION}")
 # Option to build as library for converged binary
 option(BUILD_ELOQSQL_AS_LIBRARY "Build eloqsql as library instead of executable" OFF)
 
+# These options are consumed by both storage/eloq and Data Substrate. Declare
+# them before either subdirectory is configured so a fresh build generates
+# consistent compile definitions on its first CMake pass.
+OPTION(ELOQ_MODULE_ENABLED "Register the tx service as an ELOQ module" ON)
+OPTION(EXT_TX_PROC_ENABLED
+  "Allow external threads to move the tx service forward" ON)
+
+# ELOQ modules are driven by external processors and access coordinator state
+# that is compiled only when EXT_TX_PROC_ENABLED is enabled.
+IF(ELOQ_MODULE_ENABLED AND NOT EXT_TX_PROC_ENABLED)
+  MESSAGE(FATAL_ERROR
+    "ELOQ_MODULE_ENABLED requires EXT_TX_PROC_ENABLED=ON")
+ENDIF()
+
+# Product submodules are initialized explicitly by
+# scripts/checkout_product_submodules.sh. Prevent EloqStore from launching a
+# recursive Git update during CMake configuration, which would also bypass the
+# Data Substrate workspace's selective checkout policy.
+SET(GIT_SUBMODULE OFF CACHE BOOL
+  "Update nested Git submodules during CMake configuration" FORCE)
+
 # IF(BUILD_ELOQSQL_AS_LIBRARY)
   SET(ELOQSQL_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
   SET(ELOQSQL_BINARY_DIR ${CMAKE_CURRENT_BINARY_DIR})
@@ -50,6 +71,56 @@ option(BUILD_ELOQSQL_AS_LIBRARY "Build eloqsql as library instead of executable"
 
 SET(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH}
   ${ELOQSQL_SOURCE_DIR}/cmake ${ELOQSQL_SOURCE_DIR}/cmake/Internal/CPack)
+
+# Prefer the dependency workspace owned by Data Substrate. The second path is
+# used when EloqSQL is built as part of a converged parent project.
+SET(ELOQ_THIRD_PARTY_HELPER_CANDIDATES
+  "${CMAKE_CURRENT_SOURCE_DIR}/data_substrate/cmake/EloqThirdParty.cmake"
+  "${CMAKE_CURRENT_SOURCE_DIR}/../data_substrate/cmake/EloqThirdParty.cmake")
+
+IF(DATA_SUBSTRATE_DIR)
+  SET(ELOQ_THIRD_PARTY_HELPER_CANDIDATES
+    "${DATA_SUBSTRATE_DIR}/cmake/EloqThirdParty.cmake"
+    ${ELOQ_THIRD_PARTY_HELPER_CANDIDATES})
+ENDIF()
+
+FOREACH(ELOQ_THIRD_PARTY_HELPER ${ELOQ_THIRD_PARTY_HELPER_CANDIDATES})
+  IF(EXISTS "${ELOQ_THIRD_PARTY_HELPER}")
+    INCLUDE("${ELOQ_THIRD_PARTY_HELPER}")
+    SET(ELOQ_THIRD_PARTY_HELPER_FOUND TRUE)
+    BREAK()
+  ENDIF()
+ENDFOREACH()
+
+IF(ELOQ_THIRD_PARTY_REQUIRED AND NOT ELOQ_THIRD_PARTY_HELPER_FOUND)
+  MESSAGE(FATAL_ERROR
+    "ELOQ_THIRD_PARTY_REQUIRED is ON, but data_substrate/cmake/EloqThirdParty.cmake was not found")
+ENDIF()
+
+# Data Substrate's host-manager target consumes yaml-cpp through FetchContent.
+# Reuse the manifest-fetched checkout so configuring EloqSQL does not perform a
+# second, out-of-workspace clone.
+IF(ELOQ_THIRD_PARTY_ROOT AND
+   EXISTS "${ELOQ_THIRD_PARTY_ROOT}/src/yaml-cpp/CMakeLists.txt")
+  IF(NOT DEFINED FETCHCONTENT_SOURCE_DIR_YAML-CPP OR
+     "${FETCHCONTENT_SOURCE_DIR_YAML-CPP}" STREQUAL "")
+    SET("FETCHCONTENT_SOURCE_DIR_YAML-CPP"
+      "${ELOQ_THIRD_PARTY_ROOT}/src/yaml-cpp"
+      CACHE PATH "yaml-cpp source managed by the Data Substrate workspace"
+      FORCE)
+  ENDIF()
+ENDIF()
+
+# Keep older Data Substrate revisions usable for downstream/converged builds.
+IF(NOT COMMAND eloq_assert_under_prefix)
+  FUNCTION(eloq_assert_under_prefix path_var description)
+  ENDFUNCTION()
+ENDIF()
+
+IF(NOT COMMAND eloq_assert_target_under_prefix)
+  FUNCTION(eloq_assert_target_under_prefix target description)
+  ENDFUNCTION()
+ENDIF()
 
 # Use a default manufacturer if no manufacturer was identified.
 IF(NOT DEFINED MANUFACTURER) 
@@ -639,4 +710,3 @@ IF(NOT WITHOUT_SERVER AND NOT BUILD_ELOQSQL_AS_LIBRARY)
     WORKING_DIRECTORY ${ELOQSQL_BINARY_DIR}/mysql-test)
   ADD_DEPENDENCIES(smoketest minbuild)
 ENDIF()
-

--- a/README.md
+++ b/README.md
@@ -70,26 +70,38 @@ Follow the [instruction guide](https://www.eloqdata.com/eloqsql/install-from-bin
 
 Follow these steps to build and run EloqSQL from source.
 
-### 1. Install Dependencies
-We recommend using our Docker image with pre-installed dependencies for a quick build and run of EloqSQL.
+### 1. Pull the Source Code
+
+We recommend using our Docker image with pre-installed system tools for a quick build and run of EloqSQL.
 
 ```bash
 docker pull eloqdata/eloq-dev-ci-ubuntu2404:latest
+git clone https://github.com/eloqdata/eloqsql.git
+cd eloqsql
 ```
 
-Or, you can manually run the following script to install dependencies on your local machine (Ubuntu 24.04 example).
+Alternatively, clone EloqSQL in an existing Linux environment. Ubuntu 24.04 is preferred.
 
 ```bash
+git clone https://github.com/eloqdata/eloqsql.git
+cd eloqsql
+```
+
+### 2. Initialize Submodules and Dependencies
+
+Initialize product source submodules, then install the build dependencies:
+
+```bash
+bash scripts/checkout_product_submodules.sh
 bash scripts/install_dependency_ubuntu2404.sh
 ```
 
-### 2. Initialize Submodules
-Fetch the Transaction Service and its dependencies:
-
-```
-git submodule update --init --recursive
-```
-
+The checkout script intentionally skips `data_substrate/third_party/src/*`.
+The dependency installer uses Data Substrate's manifest to fetch and build the
+shared source dependencies (including brpc, braft, mimalloc, Abseil, gRPC, and
+RocksDB) under `data_substrate/third_party/`. Libraries and headers are installed
+to `data_substrate/third_party/install`, not `/usr` or `/usr/local`. Dependency
+compilation is limited to eight CPU cores.
 
 ### 3. Build EloqSQL
 Configure and compile with optimized settings:
@@ -122,12 +134,22 @@ cmake -DCMAKE_INSTALL_PREFIX=${HOME}/install \
       -DBRPC_WITH_GLOG=ON \
       -DMARIA_WITH_GLOG=ON \
       -DWITH_ASAN=OFF \
+      -DELOQ_THIRD_PARTY_PREFIX="${PWD}/../data_substrate/third_party/install" \
+      -DELOQ_THIRD_PARTY_REQUIRED=ON \
       -DCMAKE_C_FLAGS_RELWITHDEBINFO="-O2 -g -DNDEBUG -DDBUG_OFF -fno-omit-frame-pointer -fno-strict-aliasing" \
       -DCMAKE_CXX_FLAGS_RELWITHDEBINFO="-O2 -g -DNDEBUG -DDBUG_OFF -fno-omit-frame-pointer -fno-strict-aliasing -felide-constructors -Wno-error" \
       -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 \
       ../
 cmake --build . --config RelWithDebInfo -j8
 cmake --install . --config RelWithDebInfo
+```
+
+Executables built from source link to libraries in the shared workspace. Add
+them to the runtime search path before starting EloqSQL:
+
+```bash
+cd ..
+export LD_LIBRARY_PATH="$PWD/data_substrate/third_party/install/lib:$PWD/data_substrate/third_party/install/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
 ```
 
 ### 4. Set Up Storage Backend
@@ -338,5 +360,3 @@ To deploy EloqSQL cluster, Please refer to [EloqCtl](https://www.eloqdata.com/el
 ---
 
 **Star This Repo ⭐** to Support Our Journey — Every Star Helps Us Reach More Developers!  
-
-

--- a/concourse/pipeline/build_debug_tarball.yml
+++ b/concourse/pipeline/build_debug_tarball.yml
@@ -11,27 +11,6 @@ resources:
   source:
     repository: eloqdata/eloq-build-ubuntu2204
 
-- name: logservice_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/eloq_log_service.git
-
-- name: raft_host_manager_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/raft_host_manager.git
-
-- name: eloqstore_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/eloqstore.git
-
 jobs:
 - name: ubuntu2204-main
   plan:
@@ -40,12 +19,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2204
         resource: image_ubuntu2204_main
 

--- a/concourse/pipeline/build_nightly_tarball.yml
+++ b/concourse/pipeline/build_nightly_tarball.yml
@@ -29,27 +29,6 @@ resources:
   source:
     repository: eloqdata/eloq-dev-ci-centos7
 
-- name: logservice_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/eloq_log_service.git
-
-- name: raft_host_manager_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/raft_host_manager.git
-
-- name: eloqstore_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/eloqstore.git
-
 jobs:
 - name: ubuntu2004-main
   plan:
@@ -58,12 +37,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2004
         resource: image_ubuntu2004_main
 
@@ -121,12 +94,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2204
         resource: image_ubuntu2204_main
 
@@ -184,12 +151,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2404
         resource: image_ubuntu2404_main
 
@@ -247,12 +208,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_centos7
         resource: image_centos7_main
 

--- a/concourse/pipeline/build_release_tarball.yml
+++ b/concourse/pipeline/build_release_tarball.yml
@@ -37,27 +37,6 @@ resources:
   source:
     repository: eloqdata/eloq-dev-ci-rocky9
 
-- name: logservice_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/eloq_log_service.git
-
-- name: raft_host_manager_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/raft_host_manager.git
-
-- name: eloqstore_src_main
-  type: git
-  source:
-    branch: main
-    private_key: ((git-key))
-    uri: git@github.com:eloqdata/eloqstore.git
-
 jobs:
 - name: ubuntu2004-main
   plan:
@@ -66,12 +45,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2004
         resource: image_ubuntu2004_main
 
@@ -136,12 +109,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2204
         resource: image_ubuntu2204_main
 
@@ -205,12 +172,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_ubuntu2404
         resource: image_ubuntu2404_main
 
@@ -275,12 +236,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_centos7
         resource: image_centos7_main
 
@@ -345,12 +300,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_centos8
         resource: image_centos8_main
 
@@ -410,12 +359,6 @@ jobs:
       steps:
       - get: eloqsql_src
         resource: eloqsql_src_main
-      - get: logservice_src
-        resource: logservice_src_main
-      - get: raft_host_manager_src
-        resource: raft_host_manager_src_main
-      - get: eloqstore_src
-        resource: eloqstore_src_main
       - get: image_rocky9
         resource: image_rocky9_main
 

--- a/concourse/pipeline/build_tarball_open.yml
+++ b/concourse/pipeline/build_tarball_open.yml
@@ -12,20 +12,6 @@ resources:
       repository: ubuntu
       tag: "24.04"
 
-  - name: logservice_src_main
-    type: git
-    source:
-      branch: main
-      private_key: ((git-key))
-      uri: git@github.com:eloqdata/log_service.git
-
-  - name: raft_host_manager_src_main
-    type: git
-    source:
-      branch: main
-      private_key: ((git-key))
-      uri: git@github.com:eloqdata/raft_host_manager.git
-
 jobs:
   - name: ubuntu2404-debug-openlog
     plan:
@@ -34,10 +20,6 @@ jobs:
           steps:
             - get: eloqsql_src
               resource: eloqsql_src_main
-            - get: logservice_src
-              resource: logservice_src_main
-            - get: raft_host_manager_src
-              resource: raft_host_manager_src_main
             - get: image_ubuntu2404
               resource: image_ubuntu2404_main
 
@@ -50,4 +32,3 @@ jobs:
           OUT_NAME: debug-openlog
 
     serial: true
-

--- a/concourse/pipeline/main.ent.yml
+++ b/concourse/pipeline/main.ent.yml
@@ -7,27 +7,11 @@ resources:
     uri: git@github.com:eloqdata/eloqsql.git
     private_key: ((git-key))
 
-- name: logservice_src
-  type: git
-  check_every: 3m
-  source:
-    branch: main
-    uri: git@github.com:eloqdata/eloq_log_service.git
-    private_key: ((git-key))
-
 - name: eloq_test_src
   type: git
   source:
     branch: main
     uri: git@github.com:eloqdata/eloq-test.git
-    private_key: ((git-key))
-
-- name: raft_host_manager_src
-  type: git
-  check_every: 3m
-  source:
-    branch: main
-    uri: git@github.com:eloqdata/raft_host_manager.git
     private_key: ((git-key))
 
 - name: eloq_ubuntu_2404
@@ -45,10 +29,6 @@ jobs:
   - in_parallel:
       steps:
       - get: eloqsql_src
-        trigger: true
-      - get: logservice_src
-        trigger: true
-      - get: raft_host_manager_src
         trigger: true
       - get: eloq_test_src
         trigger: true

--- a/concourse/pipeline/pr.ent.yml
+++ b/concourse/pipeline/pr.ent.yml
@@ -16,25 +16,11 @@ resources:
     disable_forks: false
     labels: ["trigger-ci"]
 
-- name: logservice_src
-  type: git
-  source:
-    branch: main
-    uri: git@github.com:eloqdata/eloq_log_service.git
-    private_key: ((git-key))
-
 - name: eloq_test_src
   type: git
   source:
     branch: main
     uri: git@github.com:eloqdata/eloq-test.git
-    private_key: ((git-key))
-
-- name: raft_host_manager_src
-  type: git
-  source:
-    branch: main
-    uri: git@github.com:eloqdata/raft_host_manager.git
     private_key: ((git-key))
 
 - name: eloq_ubuntu_2404
@@ -51,9 +37,7 @@ jobs:
   plan:
   - in_parallel:
       steps:
-      - get: logservice_src
       - get: eloq_test_src
-      - get: raft_host_manager_src
       - get: eloqsql_pr
         trigger: true
         version: every
@@ -81,4 +65,3 @@ jobs:
     params:
       path: eloqsql_pr
       status: success
-

--- a/concourse/pipeline/tag.yml
+++ b/concourse/pipeline/tag.yml
@@ -6,14 +6,6 @@ jobs:
           limit: 2
           steps:
             - get: eloqsql_src
-              params:
-                submodules: all
-            - get: logservice_src
-              params:
-                submodules: all
-            - get: raft_host_manager_src
-              params:
-                submodules: all
             - get: base_image
       - task: new-tag
         image: base_image
@@ -28,14 +20,6 @@ jobs:
           limit: 2
           steps:
             - get: eloqsql_src
-              params:
-                submodules: all
-            - get: logservice_src
-              params:
-                submodules: all
-            - get: raft_host_manager_src
-              params:
-                submodules: all
             - get: base_image
       - task: new-tag
         image: base_image
@@ -50,14 +34,6 @@ jobs:
           limit: 2
           steps:
             - get: eloqsql_src
-              params:
-                submodules: all
-            - get: logservice_src
-              params:
-                submodules: all
-            - get: raft_host_manager_src
-              params:
-                submodules: all
             - get: base_image
       - task: new-tag
         image: base_image
@@ -78,15 +54,3 @@ resources:
       private_key: ((git-key))
       uri: git@github.com:eloqdata/eloqsql.git
     type: git
-  - name: logservice_src
-    type: git
-    source:
-      branch: main
-      uri: git@github.com:eloqdata/eloq_log_service.git
-      private_key: ((git-key))
-  - name: raft_host_manager_src
-    type: git
-    source:
-      branch: main
-      uri: git@github.com:eloqdata/raft_host_manager.git
-      private_key: ((git-key))

--- a/concourse/scripts/build_tarball.bash
+++ b/concourse/scripts/build_tarball.bash
@@ -22,31 +22,19 @@ sudo chown -R $current_user $HOME/workspace 2>/dev/null || true
 cd $HOME
 ln -s ${WORKSPACE}/eloqsql_src eloqsql
 cd eloqsql
-git submodule sync
-git submodule update --init --recursive
-
-ln -s $WORKSPACE/logservice_src data_substrate/eloq_log_service
-pushd data_substrate/eloq_log_service
-git submodule sync
-git submodule update --init --recursive
-popd
-
-pushd data_substrate/tx_service
-ln -s $WORKSPACE/raft_host_manager_src raft_host_manager
-popd
-
-if [ "${DATA_STORE_TYPE}" = "ELOQDSS_ELOQSTORE" ]; then
-    pushd data_substrate/store_handler/eloq_data_store_service
-    ln -s $WORKSPACE/eloqstore_src eloqstore
-    cd eloqstore
-    git submodule sync
-    git submodule update --init --recursive
-    popd
-fi
+bash scripts/checkout_product_submodules.sh
 
 ELOQSQL_SRC=${PWD}
 
-export LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib64:$LD_LIBRARY_PATH
+if [ -f "data_substrate/third_party/install/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX="${PWD}/data_substrate/third_party/install"
+elif [ -f "/opt/eloq/third_party/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party
+fi
+if [ -n "${ELOQ_THIRD_PARTY_PREFIX:-}" ]; then
+    export CMAKE_PREFIX_PATH="${ELOQ_THIRD_PARTY_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+fi
+export LD_LIBRARY_PATH="${ELOQ_THIRD_PARTY_PREFIX:+${ELOQ_THIRD_PARTY_PREFIX}/lib:${ELOQ_THIRD_PARTY_PREFIX}/lib64:}/usr/local/lib:/usr/local/lib64:${LD_LIBRARY_PATH:-}"
 
 # Get OS information from /etc/os-release
 source /etc/os-release
@@ -77,8 +65,6 @@ if [[ "$OS_ID" == rhel* ]]; then
         INSTALL_PSQL="sudo dnf install -y postgresql"
         # detected dubious ownership
         git config --global --add safe.directory ${WORKSPACE}/eloqsql_src
-        git config --global --add safe.directory ${WORKSPACE}/logservice_src
-        git config --global --add safe.directory ${WORKSPACE}/raft_host_manager_src
         ;;
     esac
 elif [[ "$OS_ID" == ubuntu* ]]; then
@@ -203,6 +189,7 @@ cmake -DCMAKE_INSTALL_PREFIX="${DEST_DIR}" \
       -DFORK_HM_PROCESS=ON \
       -DELOQ_MODULE_ENABLED=ON \
       -DWITH_LOG_STATE=${WITH_LOG_STATE} \
+      ${ELOQ_THIRD_PARTY_PREFIX:+-DELOQ_THIRD_PARTY_PREFIX=${ELOQ_THIRD_PARTY_PREFIX} -DELOQ_THIRD_PARTY_REQUIRED=ON} \
       ../
 
 cmake --build . --config ${BUILD_TYPE} -j4

--- a/concourse/scripts/build_tarball_open.bash
+++ b/concourse/scripts/build_tarball_open.bash
@@ -28,6 +28,13 @@ fi
 : "${ASAN:=OFF}"
 : "${DATA_STORE_TYPE:=ELOQDSS_ROCKSDB_CLOUD_S3}"
 : "${NCORE:=8}"
+if ! [[ "${NCORE}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "NCORE must be a positive integer" >&2
+  exit 1
+fi
+if [ "${NCORE}" -gt 8 ]; then
+  NCORE=8
+fi
 
 DEST_DIR="${HOME}/EloqSQL"
 OUT_NAME="${OUT_NAME:-debug-openlog}"
@@ -35,11 +42,13 @@ OUT_NAME="${OUT_NAME:-debug-openlog}"
 # Prepare workspace layout expected by scripts
 cd "$HOME"
 ln -sfn "${WORKSPACE}/eloqsql_src" eloqsql
-ln -sfn "${WORKSPACE}/logservice_src" logservice_src || true
-mkdir -p eloqsql/storage/eloq/tx_service
-ln -sfn "${WORKSPACE}/raft_host_manager_src" eloqsql/storage/eloq/tx_service/raft_host_manager || true
 
 ELOQSQL_SRC="${HOME}/eloqsql"
+
+# Product source submodules must be initialized before the Data Substrate
+# workspace installer can be invoked.
+cd "$ELOQSQL_SRC"
+bash scripts/checkout_product_submodules.sh
 
 # Install all dependencies using Ubuntu 24.04 script
 source /etc/os-release
@@ -52,18 +61,9 @@ if [[ "$ID" == ubuntu* ]]; then
   source $HOME/venv/bin/activate
 fi
 
-# Initialize submodules per README
-cd "$ELOQSQL_SRC"
-git submodule sync
-git submodule update --init --recursive
-
-# Also ensure log_service submodules
-if [ -d "storage/eloq/log_service" ]; then
-  pushd storage/eloq/log_service
-  git submodule sync
-  git submodule update --init --recursive
-  popd
-fi
+export ELOQ_THIRD_PARTY_PREFIX="${ELOQSQL_SRC}/data_substrate/third_party/install"
+export CMAKE_PREFIX_PATH="${ELOQ_THIRD_PARTY_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+export LD_LIBRARY_PATH="${ELOQ_THIRD_PARTY_PREFIX}/lib:${ELOQ_THIRD_PARTY_PREFIX}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 
 # Build EloqSQL per README with OPEN_LOG_SERVICE enabled
 mkdir build
@@ -94,6 +94,8 @@ cmake -DCMAKE_INSTALL_PREFIX="${DEST_DIR}" \
       -DBRPC_WITH_GLOG=ON \
       -DMARIA_WITH_GLOG=ON \
       -DWITH_ASAN="${ASAN}" \
+      -DELOQ_THIRD_PARTY_PREFIX="${ELOQSQL_SRC}/data_substrate/third_party/install" \
+      -DELOQ_THIRD_PARTY_REQUIRED=ON \
       -DCMAKE_C_FLAGS_DEBUG="-O0 -g -DDBUG_ON -fno-omit-frame-pointer -fno-strict-aliasing" \
       -DCMAKE_CXX_FLAGS_DEBUG="-O0 -g -DDBUG_ON -fno-omit-frame-pointer -fno-strict-aliasing -felide-constructors -Wno-error" \
       -DWITH_DATA_STORE="${DATA_STORE_TYPE}" \
@@ -120,7 +122,7 @@ copy_libraries "${DEST_DIR}/bin/mariadbd" "${DEST_DIR}/lib"
 copy_libraries "${DEST_DIR}/bin/mariadb" "${DEST_DIR}/lib"
 
 # Build and include dss_server component
-pushd "${ELOQSQL_SRC}/storage/eloq/store_handler/eloq_data_store_service"
+pushd "${ELOQSQL_SRC}/data_substrate/store_handler/eloq_data_store_service"
 rm -rf bld
 mkdir bld && cd bld
 cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" -DWITH_DATA_STORE="${DATA_STORE_TYPE}" ../
@@ -130,7 +132,7 @@ mv dss_server "${DEST_DIR}/bin/"
 popd
 
 # Build and include log_service (launch_sv)
-pushd "${ELOQSQL_SRC}/storage/eloq/log_service"
+pushd "${ELOQSQL_SRC}/data_substrate/eloq_log_service"
 rm -rf bld
 mkdir bld && cd bld
 cmake -DCMAKE_BUILD_TYPE="${BUILD_TYPE}" ../
@@ -146,7 +148,7 @@ tar -czvf eloqsql.tar.gz -C "${HOME}" EloqSQL
 # Cleanup build directories
 cd "${ELOQSQL_SRC}"
 rm -rf build
-rm -rf storage/eloq/store_handler/eloq_data_store_service/bld
-rm -rf storage/eloq/log_service/bld
+rm -rf data_substrate/store_handler/eloq_data_store_service/bld
+rm -rf data_substrate/eloq_log_service/bld
 
 echo "Build completed. Tarball created at: ${HOME}/eloqsql.tar.gz"

--- a/concourse/scripts/main.bash
+++ b/concourse/scripts/main.bash
@@ -26,8 +26,17 @@ ln -s $WORKSPACE/eloqsql_src eloqsql
 ln -s $WORKSPACE/eloq_test_src eloq_test
 
 cd /home/$current_user/workspace/eloqsql
-git submodule sync
-git submodule update --init --recursive
+bash scripts/checkout_product_submodules.sh
+
+if [ -f "/opt/eloq/third_party/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party
+elif [ -f "data_substrate/third_party/install/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX="${PWD}/data_substrate/third_party/install"
+fi
+if [ -n "${ELOQ_THIRD_PARTY_PREFIX:-}" ]; then
+    export CMAKE_PREFIX_PATH="${ELOQ_THIRD_PARTY_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+    export LD_LIBRARY_PATH="${ELOQ_THIRD_PARTY_PREFIX}/lib:${ELOQ_THIRD_PARTY_PREFIX}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
 
 # setup mc command
 # minio_server_alias will be used by mtr script for clean up mimio bucket
@@ -125,7 +134,8 @@ if [ ! -f "Makefile" ]; then
           -DMARIA_WITH_GLOG=ON \
           -DSTATISTICS=ON \
           -DWITH_DATA_STORE=ELOQDSS_ROCKSDB_CLOUD_S3 \
-      -DELOQ_MODULE_ENABLED=ON \
+          -DELOQ_MODULE_ENABLED=ON \
+          ${ELOQ_THIRD_PARTY_PREFIX:+-DELOQ_THIRD_PARTY_PREFIX=${ELOQ_THIRD_PARTY_PREFIX} -DELOQ_THIRD_PARTY_REQUIRED=ON} \
           ../
 fi
 
@@ -146,7 +156,7 @@ echo "installing dss_server"
 cp dss_server /home/$current_user/workspace/eloqsql/install/bin/
 
 echo "building log_server"
-cd /home/$current_user/workspace/eloqsql/data_substrate/log_service
+cd /home/$current_user/workspace/eloqsql/data_substrate/eloq_log_service
 mkdir bld && cd bld
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON ../
 cmake --build . --config Debug -j8

--- a/concourse/scripts/main.ent.bash
+++ b/concourse/scripts/main.ent.bash
@@ -26,13 +26,17 @@ ln -s $WORKSPACE/eloqsql_src eloqsql
 ln -s $WORKSPACE/eloq_test_src eloq_test
 
 cd /home/$current_user/workspace/eloqsql
-git submodule sync
-git submodule update --init --recursive
+bash scripts/checkout_product_submodules.sh
 
-cd /home/$current_user/workspace/eloqsql/data_substrate
-ln -s $WORKSPACE/logservice_src eloq_log_service
-cd tx_service
-ln -s $WORKSPACE/raft_host_manager_src raft_host_manager
+if [ -f "/opt/eloq/third_party/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party
+elif [ -f "data_substrate/third_party/install/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX="${PWD}/data_substrate/third_party/install"
+fi
+if [ -n "${ELOQ_THIRD_PARTY_PREFIX:-}" ]; then
+    export CMAKE_PREFIX_PATH="${ELOQ_THIRD_PARTY_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+    export LD_LIBRARY_PATH="${ELOQ_THIRD_PARTY_PREFIX}/lib:${ELOQ_THIRD_PARTY_PREFIX}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+fi
 
 # setup mc command
 # minio_server_alias will be used by mtr script for clean up mimio bucket
@@ -131,8 +135,9 @@ if [ ! -f "Makefile" ]; then
           -DWITH_DATA_STORE=ELOQDSS_ELOQSTORE \
           -DOPEN_LOG_SERVICE=OFF \
           -DFORK_HM_PROCESS=ON \
-	  -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
-      -DELOQ_MODULE_ENABLED=ON \
+          -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
+          -DELOQ_MODULE_ENABLED=ON \
+          ${ELOQ_THIRD_PARTY_PREFIX:+-DELOQ_THIRD_PARTY_PREFIX=${ELOQ_THIRD_PARTY_PREFIX} -DELOQ_THIRD_PARTY_REQUIRED=ON} \
           ../
 fi
 
@@ -153,7 +158,7 @@ echo "installing dss_server"
 cp dss_server /home/$current_user/workspace/eloqsql/install/bin/
 
 echo "building log_server"
-cd /home/$current_user/workspace/eloqsql/data_substrate/log_service
+cd /home/$current_user/workspace/eloqsql/data_substrate/eloq_log_service
 mkdir bld && cd bld
 cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 ../
 cmake --build . --config Debug -j8

--- a/concourse/scripts/pr.ent.bash
+++ b/concourse/scripts/pr.ent.bash
@@ -30,30 +30,17 @@ ln -s $WORKSPACE/eloqsql_pr eloqsql
 ln -s $WORKSPACE/eloq_test_src eloq_test
 
 cd /home/$current_user/workspace/eloqsql
-git submodule sync
-git submodule update --init --recursive
-pr_branch_name=$(cat .git/resource/metadata.json | jq -r '.[] | select(.name=="head_name") | .value')
+bash scripts/checkout_product_submodules.sh
 
-cd /home/$current_user/workspace/eloqsql/data_substrate
-ln -s $WORKSPACE/logservice_src eloq_log_service
-
-cd eloq_log_service
-if [ -n "$pr_branch_name" ] && git ls-remote --exit-code --heads origin "$pr_branch_name" > /dev/null; then
-  git fetch origin '+refs/heads/*:refs/remotes/origin/*'
-  git checkout -b ${pr_branch_name} origin/${pr_branch_name}
-  git submodule update --init --recursive
+if [ -f "/opt/eloq/third_party/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX=/opt/eloq/third_party
+elif [ -f "data_substrate/third_party/install/share/eloq/third-party-manifest.yml" ]; then
+    export ELOQ_THIRD_PARTY_PREFIX="${PWD}/data_substrate/third_party/install"
 fi
-cd ..
-
-cd tx_service
-ln -s $WORKSPACE/raft_host_manager_src raft_host_manager
-cd raft_host_manager
-if [ -n "$pr_branch_name" ] && git ls-remote --exit-code --heads origin "$pr_branch_name" > /dev/null; then
-  git fetch origin '+refs/heads/*:refs/remotes/origin/*'
-  git checkout -b ${pr_branch_name} origin/${pr_branch_name}
-  git submodule update --init --recursive
+if [ -n "${ELOQ_THIRD_PARTY_PREFIX:-}" ]; then
+    export CMAKE_PREFIX_PATH="${ELOQ_THIRD_PARTY_PREFIX}${CMAKE_PREFIX_PATH:+:${CMAKE_PREFIX_PATH}}"
+    export LD_LIBRARY_PATH="${ELOQ_THIRD_PARTY_PREFIX}/lib:${ELOQ_THIRD_PARTY_PREFIX}/lib64${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
 fi
-cd ..
 
 # setup mc command
 # minio_server_alias will be used by mtr script for clean up mimio bucket
@@ -153,8 +140,9 @@ if [ ! -f "Makefile" ]; then
           -DWITH_DATA_STORE=ELOQDSS_ELOQSTORE \
           -DOPEN_LOG_SERVICE=OFF \
           -DFORK_HM_PROCESS=ON \
-	  -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
-      -DELOQ_MODULE_ENABLED=ON \
+          -DWITH_LOG_STATE=ROCKSDB_CLOUD_S3 \
+          -DELOQ_MODULE_ENABLED=ON \
+          ${ELOQ_THIRD_PARTY_PREFIX:+-DELOQ_THIRD_PARTY_PREFIX=${ELOQ_THIRD_PARTY_PREFIX} -DELOQ_THIRD_PARTY_REQUIRED=ON} \
           ../
 fi
 

--- a/concourse/scripts/tag.sh
+++ b/concourse/scripts/tag.sh
@@ -14,10 +14,7 @@ fi
 cd $HOME
 ln -s ${WORKSPACE}/eloqsql_src eloqsql
 cd eloqsql
-ln -s $WORKSPACE/logservice_src data_substrate/eloq_log_service
-pushd data_substrate/tx_service
-ln -s $WORKSPACE/raft_host_manager_src raft_host_manager
-popd
+bash scripts/checkout_product_submodules.sh
 
 git config --global user.email "concourse@noreply.com"
 git config --global user.name "concourse-ci"

--- a/concourse/tasks/build_debug_tarball.yml
+++ b/concourse/tasks/build_debug_tarball.yml
@@ -3,9 +3,6 @@ image_resource:
   type: registry-image
 inputs:
   - name: eloqsql_src
-  - name: logservice_src
-  - name: raft_host_manager_src
-  - name: eloqstore_src
 outputs:
   - name: the-output
 run:

--- a/concourse/tasks/build_nightly_tarball.yml
+++ b/concourse/tasks/build_nightly_tarball.yml
@@ -3,9 +3,6 @@ image_resource:
   type: registry-image
 inputs:
   - name: eloqsql_src
-  - name: logservice_src
-  - name: raft_host_manager_src
-  - name: eloqstore_src
 outputs:
   - name: the-output
 run:

--- a/concourse/tasks/build_release_tarball.yml
+++ b/concourse/tasks/build_release_tarball.yml
@@ -3,9 +3,6 @@ image_resource:
   type: registry-image
 inputs:
   - name: eloqsql_src
-  - name: logservice_src
-  - name: raft_host_manager_src
-  - name: eloqstore_src
 outputs:
   - name: the-output
 params:

--- a/concourse/tasks/build_tarball_open.yml
+++ b/concourse/tasks/build_tarball_open.yml
@@ -3,8 +3,6 @@ image_resource:
   type: registry-image
 inputs:
   - name: eloqsql_src
-  - name: logservice_src
-  - name: raft_host_manager_src
 outputs:
   - name: the-output
 run:

--- a/concourse/tasks/main.ent.yml
+++ b/concourse/tasks/main.ent.yml
@@ -4,7 +4,5 @@ image_resource:
 inputs:
   - name: eloqsql_src
   - name: eloq_test_src
-  - name: raft_host_manager_src
-  - name: logservice_src
 run:
   path: eloqsql_src/concourse/scripts/main.ent.bash

--- a/concourse/tasks/pr.ent.yml
+++ b/concourse/tasks/pr.ent.yml
@@ -4,7 +4,5 @@ image_resource:
 inputs:
   - name: eloqsql_pr
   - name: eloq_test_src
-  - name: raft_host_manager_src
-  - name: logservice_src
 run:
   path: eloqsql_pr/concourse/scripts/pr.ent.bash

--- a/concourse/tasks/tag.yml
+++ b/concourse/tasks/tag.yml
@@ -3,8 +3,6 @@ image_resource:
   type: registry-image
 inputs:
   - name: eloqsql_src
-  - name: logservice_src
-  - name: raft_host_manager_src
 run:
   path: /bin/bash
   args:

--- a/scripts/checkout_product_submodules.sh
+++ b/scripts/checkout_product_submodules.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+DATA_SUBSTRATE_DIR=data_substrate
+
+cd "${REPO_ROOT}"
+
+git submodule sync
+
+# Initialize top-level product source dependencies without recursively pulling
+# Data Substrate's third_party/src workspace. If a developer is testing a
+# different Data Substrate checkout, preserve it.
+if [ "${ELOQ_FORCE_DATA_SUBSTRATE_UPDATE:-0}" = "1" ] || \
+   git diff --quiet -- "${DATA_SUBSTRATE_DIR}"; then
+  git submodule update --init
+else
+  mapfile -t PRODUCT_SUBMODULES < <(
+    git config -f .gitmodules --get-regexp '\.path$' |
+      awk -v data_substrate="${DATA_SUBSTRATE_DIR}" '$2 != data_substrate { print $2 }'
+  )
+  if [ "${#PRODUCT_SUBMODULES[@]}" -gt 0 ]; then
+    git submodule update --init -- "${PRODUCT_SUBMODULES[@]}"
+  fi
+  echo "Keeping locally checked-out ${DATA_SUBSTRATE_DIR}; parent gitlink has uncommitted changes."
+fi
+
+# tx-log-protos, eloq_log_service, and raft_host_manager are bundled in-tree by
+# Data Substrate. EloqStore and its source dependencies remain product
+# submodules; third_party/src is fetched by the third-party installer.
+git -C "${DATA_SUBSTRATE_DIR}" submodule sync
+git -C "${DATA_SUBSTRATE_DIR}" submodule update --init \
+  store_handler/eloq_data_store_service/eloqstore
+
+ELOQSTORE_DIR=${DATA_SUBSTRATE_DIR}/store_handler/eloq_data_store_service/eloqstore
+if [ -f "${ELOQSTORE_DIR}/.gitmodules" ]; then
+  git -C "${ELOQSTORE_DIR}" submodule sync
+  git -C "${ELOQSTORE_DIR}" submodule update --init \
+    external/concurrentqueue \
+    external/inih \
+    external/abseil
+fi

--- a/scripts/git-checkout.sh
+++ b/scripts/git-checkout.sh
@@ -11,47 +11,7 @@ git checkout "${TAG}"
 if [ "${TAG}" = "main" ]; then
   git pull origin main
 fi
-git submodule update --init --recursive
 
-if [ "${TAG}" = "main" ]; then
-  if [ -d storage/eloq/eloq_log_service ]; then
-    pushd storage/eloq/eloq_log_service
-    git checkout main
-    git pull origin main
-    git submodule update --init --recursive
-    popd
-  fi
-
-  if [ -d storage/eloq/tx_service/raft_host_manager ]; then
-    pushd storage/eloq/tx_service/raft_host_manager
-    git checkout main
-    git pull origin main
-    popd
-  fi
-else
-  REL_BRANCH="rel_${TAG//./_}_eloqsql"
-  if [ -d storage/eloq/eloq_log_service ]; then
-    pushd storage/eloq/eloq_log_service
-    git fetch origin '+refs/heads/*:refs/remotes/origin/*'
-    if git ls-remote --heads origin "$REL_BRANCH" | grep -q "$REL_BRANCH"; then
-      git checkout -b "$REL_BRANCH" "origin/$REL_BRANCH"
-    else
-      echo "Expected release branch $REL_BRANCH not found in eloq_log_service"
-      exit 1
-    fi
-    git submodule update --init --recursive
-    popd
-  fi
-
-  if [ -d storage/eloq/tx_service/raft_host_manager ]; then
-    pushd storage/eloq/tx_service/raft_host_manager
-    git fetch origin '+refs/heads/*:refs/remotes/origin/*'
-    if git ls-remote --heads origin "$REL_BRANCH" | grep -q "$REL_BRANCH"; then
-      git checkout -b "$REL_BRANCH" "origin/$REL_BRANCH"
-    else
-      echo "Expected release branch $REL_BRANCH not found in tx_service/raft_host_manager"
-      exit 1
-    fi
-    popd
-  fi
-fi
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+ELOQ_FORCE_DATA_SUBSTRATE_UPDATE=1 \
+  bash "${SCRIPT_DIR}/checkout_product_submodules.sh"

--- a/scripts/git-tag.sh
+++ b/scripts/git-tag.sh
@@ -4,29 +4,6 @@ set -eo
 TAG=$1
 REL_BRANCH="rel_${TAG//./_}_eloqsql"
 
-# Utility: create and push a release branch for a module repo if available
-create_and_push_release_branch() {
-  local module_path="$1"
-  local release_branch="$2"
-  if [ -d "$module_path" ]; then
-    pushd "$module_path"
-    git fetch origin '+refs/heads/*:refs/remotes/origin/*'
-    if git show-ref --verify --quiet "refs/heads/$release_branch" || \
-       git ls-remote --heads origin "$release_branch" | grep -q "$release_branch"; then
-      echo "Error: release branch $release_branch already exists for $module_path (local or remote)" >&2
-      popd
-      exit 1
-    fi
-    echo "Creating release branch $release_branch for $module_path"
-    git checkout -b "$release_branch"
-    git push -u origin "$release_branch"
-    popd
-  else
-    echo "Error: module path $module_path does not exist" >&2
-    exit 1
-  fi
-}
-
 set +e
 git fetch origin '+refs/heads/*:refs/remotes/origin/*'
 set -e
@@ -46,8 +23,3 @@ if git show-ref --verify --quiet "refs/heads/$REL_BRANCH" || \
 fi
 git checkout -b "$REL_BRANCH" main
 git push origin "$REL_BRANCH"
-
-# Push release branch for submodules
-create_and_push_release_branch "storage/eloq/eloq_log_service" "$REL_BRANCH"
-create_and_push_release_branch "storage/eloq/tx_service/raft_host_manager" "$REL_BRANCH"
-

--- a/scripts/install_dependency_ubuntu2404.sh
+++ b/scripts/install_dependency_ubuntu2404.sh
@@ -1,10 +1,54 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+set -x
 
-set -ex
+# Install the build dependencies for a from-scratch Ubuntu 24.04 build. Source-
+# built dependencies are fetched, pinned, built, and installed by Data
+# Substrate's shared third-party workspace instead of being installed globally.
 
-# Ensure noninteractive apt; keep TZ default
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO_ROOT=$(cd "${SCRIPT_DIR}/.." && pwd)
+THIRD_PARTY_INSTALLER="${REPO_ROOT}/data_substrate/scripts/third_party/install-ubuntu2404.sh"
+THIRD_PARTY_PREFIX="${ELOQ_THIRD_PARTY_PREFIX:-${REPO_ROOT}/data_substrate/third_party/install}"
+
+if [ ! -x "${THIRD_PARTY_INSTALLER}" ]; then
+  echo "Missing ${THIRD_PARTY_INSTALLER}. Initialize product submodules first:" >&2
+  echo "  bash scripts/checkout_product_submodules.sh" >&2
+  exit 1
+fi
+
 export DEBIAN_FRONTEND=noninteractive
 export TZ=${TZ:-UTC}
+
+# Some development images expose different versions through g++ and c++. Make
+# every Data Substrate build path use the same default compiler that CMake will
+# select later for EloqSQL, while still honoring an explicitly chosen toolchain.
+export CC=${CC:-cc}
+export CXX=${CXX:-c++}
+
+run_privileged() {
+  if [ "$(id -u)" -eq 0 ]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "This script must run as root or with sudo available: $*" >&2
+    exit 1
+  fi
+}
+
+run_with_retry() {
+  local attempt
+  for attempt in 1 2 3; do
+    if "$@"; then
+      return 0
+    fi
+    if [ "${attempt}" -lt 3 ]; then
+      sleep $((attempt * 5))
+    fi
+  done
+  return 1
+}
 
 needs_tz_config=false
 if [ ! -f /etc/timezone ] || ! grep -qE '^(Etc/UTC|UTC)$' /etc/timezone; then
@@ -14,37 +58,53 @@ if [ ! -L /etc/localtime ] || [ "$(readlink -f /etc/localtime)" != "/usr/share/z
   needs_tz_config=true
 fi
 
-if $needs_tz_config; then
-  echo 'tzdata tzdata/Areas select Etc' | sudo debconf-set-selections || true
-  echo 'tzdata tzdata/Zones/Etc select UTC' | sudo debconf-set-selections || true
-  echo 'Etc/UTC' | sudo tee /etc/timezone >/dev/null
-  sudo ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
+if ${needs_tz_config}; then
+  echo 'tzdata tzdata/Areas select Etc' | run_privileged debconf-set-selections || true
+  echo 'tzdata tzdata/Zones/Etc select UTC' | run_privileged debconf-set-selections || true
+  echo 'Etc/UTC' | run_privileged tee /etc/timezone >/dev/null
+  run_privileged ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 fi
 
-# Install system packages
-DEBIAN_FRONTEND=noninteractive sudo apt-get update
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y --no-install-recommends \
-    jq sudo vim wget curl apt-utils python3 python3-dev python3-pip python3-venv \
-    python3-venv gdb libcurl4-openssl-dev build-essential libncurses5-dev \
-    gnutls-dev bison zlib1g-dev ccache rsync cmake ninja-build libuv1-dev git \
-    g++ make openjdk-11-jdk openssh-client openssh-server libssl-dev libgflags-dev \
-    libleveldb-dev libsnappy-dev openssl lcov libbz2-dev liblz4-dev libzstd-dev \
-    libboost-context-dev ca-certificates libc-ares-dev libc-ares2 m4 pkg-config \
-    tar gcc redis tcl libreadline-dev ncurses-dev patchelf libprotobuf-dev \
-    protobuf-compiler
+if ! command -v curl >/dev/null; then
+  run_privileged apt-get update || true
+  run_privileged apt-get install -y curl
+fi
 
-# Install lua
-mkdir -p $HOME/Downloads/lua && cd $HOME/Downloads/lua
-curl -fsSL https://www.lua.org/ftp/lua-5.4.6.tar.gz | tar -xzf - --strip-components=1
-make all && sudo make install
-cd ../ && rm -rf lua
+run_privileged apt-get update
+run_privileged apt-get install -y --no-install-recommends \
+  jq sudo vim wget curl apt-utils python3 python3-dev python3-pip python3-venv \
+  gdb libcurl4-openssl-dev build-essential libncurses5-dev \
+  gnutls-dev bison zlib1g-dev ccache rsync cmake ninja-build libuv1-dev git \
+  g++ make openjdk-11-jdk openssh-client openssh-server libssl-dev libgflags-dev \
+  libleveldb-dev libsnappy-dev openssl libbz2-dev liblz4-dev libzstd-dev \
+  libboost-context-dev ca-certificates libc-ares-dev libc-ares2 lcov m4 pkg-config \
+  tar gcc redis tcl libreadline-dev ncurses-dev patchelf libprotobuf-dev util-linux \
+  protobuf-compiler libjsoncpp-dev
 
-# Setup Python virtual environment and install dependencies
-python3 -m venv $HOME/venv
-source $HOME/venv/bin/activate
-pip install --no-cache-dir --upgrade pip setuptools wheel
-pip install --no-cache-dir setuptools==45.2.0 \
-    cassandra-driver==3.28.0 \
+# Preserve the Google Cloud command-line tooling used by the GCS integration
+# tests. It is not part of the native dependency prefix.
+if ! command -v gcloud >/dev/null 2>&1; then
+  run_privileged apt-get install -y apt-transport-https ca-certificates gnupg
+  echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | \
+    run_privileged tee /etc/apt/sources.list.d/google-cloud-sdk.list >/dev/null
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    run_privileged apt-key add -
+  run_privileged apt-get update
+  run_privileged apt-get install -y google-cloud-cli
+fi
+
+# Keep EloqSQL's Python test tooling separate from the C/C++ dependency
+# workspace. This mirrors EloqKV: native source dependencies belong to Data
+# Substrate, while Python packages live in a virtual environment.
+if [ "${ELOQ_SKIP_PYTHON_DEPS:-0}" != "1" ]; then
+  if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+  fi
+  export PATH="${HOME}/.local/bin:${PATH}"
+  uv venv --python /usr/bin/python3 "${HOME}/venv"
+  run_with_retry uv pip install --python "${HOME}/venv/bin/python" --no-cache-dir \
+    setuptools==45.2.0 \
+    cassandra-driver==3.29.2 \
     awscli==1.29.44 \
     boto3==1.28.36 \
     botocore==1.31.44 \
@@ -52,236 +112,26 @@ pip install --no-cache-dir setuptools==45.2.0 \
     psutil==5.9.5 \
     grpcio==1.60.0 \
     grpcio-tools==1.60.0
+fi
 
-# Install Protobuf
-mkdir -p $HOME/Downloads/protobuf && cd $HOME/Downloads/protobuf
-curl -fsSL https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.12.tar.gz | tar -xzf - --strip-components=1
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=yes \
-    -Dprotobuf_BUILD_TESTS=OFF \
-    -Dprotobuf_ABSL_PROVIDER=package \
-    -S . -B cmake-out
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install -- -j $(nproc)
-sudo ldconfig
-cd ../ && rm -rf protobuf
+# CI may restore an already-built prefix and set ELOQ_SKIP_THIRD_PARTY=1.
+if [ "${ELOQ_SKIP_THIRD_PARTY:-0}" != "1" ]; then
+  # Data Substrate currently sizes its builds with nproc. Restrict the child
+  # process to the first eight CPUs in our existing affinity set so nproc -- and
+  # every compiler it launches -- can never consume more than eight cores.
+  BUILD_CPU_LIST=$(python3 -c \
+    'import os; print(",".join(map(str, sorted(os.sched_getaffinity(0))[:8])))')
+  if [ -z "${BUILD_CPU_LIST}" ]; then
+    echo "Unable to determine CPUs available for the dependency build" >&2
+    exit 1
+  fi
 
-# Install glog
-git clone https://github.com/eloqdata/glog.git glog
-cd glog
-cmake -S . -B build -G "Unix Makefiles"
-cmake --build build -j6
-sudo cmake --build build --target install
-cd ../ && rm -rf glog
-
-# Install liburing
-git clone https://github.com/axboe/liburing.git liburing
-cd liburing
-git checkout tags/liburing-2.6
-./configure --cc=gcc --cxx=g++
-make -j4 && sudo make install
-cd .. && rm -rf liburing
-
-# Install brpc
-git clone https://github.com/eloqdata/brpc.git brpc
-cd brpc
-mkdir build && cd build
-cmake .. \
-    -DWITH_GLOG=ON \
-    -DIO_URING_ENABLED=ON \
-    -DBUILD_SHARED_LIBS=ON
-cmake --build . -j6
-sudo cp -r ./output/include/* /usr/include/
-sudo cp ./output/lib/* /usr/lib/
-cd ../../ && rm -rf brpc
-
-# Install braft
-git clone https://github.com/eloqdata/braft.git braft
-cd braft
-sed -i 's/libbrpc.a//g' CMakeLists.txt
-mkdir bld && cd bld
-cmake .. -DBRPC_WITH_GLOG=ON
-cmake --build . -j6
-sudo cp -r ./output/include/* /usr/include/
-sudo cp ./output/lib/* /usr/lib/
-cd ../../ && rm -rf braft
-
-# Install mimalloc
-git clone https://github.com/eloqdata/mimalloc.git mimalloc
-cd mimalloc
-git checkout eloq-v2.1.2
-mkdir bld && cd bld
-cmake .. && make && sudo make install
-cd ../../ && rm -rf mimalloc
-
-# Install cuckoo filter
-git clone https://github.com/eloqdata/cuckoofilter.git cuckoofilter
-cd cuckoofilter
-sudo make install
-cd .. && rm -rf cuckoofilter
-
-# Install AWSSDK
-git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git aws
-cd aws
-git checkout tags/1.11.446
-mkdir bld && cd bld
-cmake .. \
-    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
-    -DCMAKE_INSTALL_PREFIX=./output/ \
-    -DENABLE_TESTING=OFF \
-    -DBUILD_SHARED_LIBS=ON \
-    -DFORCE_SHARED_CRT=OFF \
-    -DBUILD_ONLY="dynamodb;sqs;s3;kinesis;kafka;transfer"
-cmake --build . --config RelWithDebInfo -j6
-cmake --install . --config RelWithDebInfo
-sudo cp -r ./output/include/* /usr/include/
-sudo cp -r ./output/lib/* /usr/lib/
-cd ../../ && rm -rf aws
-
-# Install rocksdb
-git clone https://github.com/facebook/rocksdb.git
-cd rocksdb
-git checkout tags/v9.1.0
-USE_RTTI=1 PORTABLE=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make -j8 shared_lib
-sudo make install-shared
-cd ../ && sudo ldconfig && rm -rf rocksdb
-
-# Install prometheus cpp client
-git clone https://github.com/jupp0r/prometheus-cpp.git
-cd prometheus-cpp
-git checkout tags/v1.1.0
-git submodule init && git submodule update
-mkdir _build && cd _build
-cmake .. -DBUILD_SHARED_LIBS=ON
-cmake --build . -j6
-sudo cmake --install .
-cd ../../ && rm -rf prometheus-cpp
-
-# Install Catch2
-git clone -b v3.3.2 https://github.com/catchorg/Catch2.git
-cd Catch2 && mkdir bld && cd bld
-cmake .. \
-    -DCMAKE_INSTALL_PREFIX=/usr/ \
-    -DCATCH_BUILD_EXAMPLES=OFF \
-    -DBUILD_TESTING=OFF
-cmake --build . -j4
-sudo cmake --install .
-cd ../../ && rm -rf Catch2
-
-# Install Abseil
-mkdir -p $HOME/Downloads/abseil-cpp && cd $HOME/Downloads/abseil-cpp
-curl -fsSL https://github.com/abseil/abseil-cpp/archive/20230802.0.tar.gz | tar -xzf - --strip-components=1
-sed -i 's/^#define ABSL_OPTION_USE_\(.*\) 2/#define ABSL_OPTION_USE_\1 0/' "absl/base/options.h"
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DABSL_BUILD_TESTING=OFF \
-    -DBUILD_SHARED_LIBS=yes \
-    -S . -B cmake-out
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install -- -j $(nproc)
-sudo ldconfig
-cd ../ && rm -rf abseil-cpp
-
-# Install RE2
-mkdir -p $HOME/Downloads/re2 && cd $HOME/Downloads/re2
-curl -fsSL https://github.com/google/re2/archive/2023-08-01.tar.gz | tar -xzf - --strip-components=1
-cmake -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=ON \
-    -DRE2_BUILD_TESTING=OFF \
-    -S . -B cmake-out
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install -- -j $(nproc)
-sudo ldconfig
-cd ../ && rm -rf re2
-
-# Install gRPC
-mkdir -p $HOME/Downloads/grpc && cd $HOME/Downloads/grpc
-curl -fsSL https://codeload.github.com/grpc/grpc/tar.gz/refs/tags/v1.51.1 | tar -xzf - --strip-components=1
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=yes \
-    -DgRPC_INSTALL=ON \
-    -DgRPC_BUILD_TESTS=OFF \
-    -DgRPC_ABSL_PROVIDER=package \
-    -DgRPC_CARES_PROVIDER=package \
-    -DgRPC_PROTOBUF_PROVIDER=package \
-    -DgRPC_RE2_PROVIDER=package \
-    -DgRPC_SSL_PROVIDER=package \
-    -DgRPC_ZLIB_PROVIDER=package \
-    -S . -B cmake-out
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install -- -j $(nproc)
-sudo ldconfig
-cd ../ && rm -rf grpc
-
-# Install crc32c
-mkdir -p $HOME/Downloads/crc32c && cd $HOME/Downloads/crc32c
-curl -fsSL https://github.com/google/crc32c/archive/1.1.2.tar.gz | tar -xzf - --strip-components=1
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=yes \
-    -DCRC32C_BUILD_TESTS=OFF \
-    -DCRC32C_BUILD_BENCHMARKS=OFF \
-    -DCRC32C_USE_GLOG=OFF \
-    -S . -B cmake-out
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install -- -j $(nproc)
-sudo ldconfig
-cd ../ && rm -rf crc32c
-
-# Install nlohmann_json
-mkdir -p $HOME/Downloads/json && cd $HOME/Downloads/json
-curl -fsSL https://github.com/nlohmann/json/archive/v3.11.2.tar.gz | tar -xzf - --strip-components=1
-cmake \
-    -DCMAKE_BUILD_TYPE=Release \
-    -DBUILD_SHARED_LIBS=yes \
-    -DBUILD_TESTING=OFF \
-    -DJSON_BuildTests=OFF \
-    -S . -B cmake-out
-sudo cmake --build cmake-out --target install -- -j $(nproc)
-sudo ldconfig
-cd ../ && rm -rf json
-
-# Install Google Cloud CPP
-mkdir -p $HOME/Downloads/google-cloud-cpp && cd $HOME/Downloads/google-cloud-cpp
-curl -fsSL https://codeload.github.com/googleapis/google-cloud-cpp/tar.gz/refs/tags/v2.24.0 | tar -xzf - --strip-components=1
-cmake -S . -B cmake-out \
-    -DCMAKE_INSTALL_PREFIX="/usr/local" \
-    -DBUILD_SHARED_LIBS=ON \
-    -DBUILD_TESTING=OFF \
-    -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
-    -DGOOGLE_CLOUD_CPP_ENABLE_EXAMPLES=OFF \
-    -DGOOGLE_CLOUD_CPP_ENABLE=bigtable,storage
-cmake --build cmake-out -- -j $(nproc)
-sudo cmake --build cmake-out --target install
-cd ../ && rm -rf google-cloud-cpp
-
-# Install Google Cloud CLI
-DEBIAN_FRONTEND=noninteractive sudo apt-get install -y apt-transport-https ca-certificates gnupg curl sudo
-echo "deb https://packages.cloud.google.com/apt cloud-sdk main" | sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
-DEBIAN_FRONTEND=noninteractive sudo apt-get update && DEBIAN_FRONTEND=noninteractive sudo apt-get install -y google-cloud-cli
-
-# Install FakeIt
-git clone https://github.com/eranpeer/FakeIt.git
-cd FakeIt
-sudo cp single_header/catch/fakeit.hpp /usr/include/catch2/fakeit.hpp
-cd ../ && rm -rf FakeIt
-
-# Install RocksDB-Cloud
-git clone https://github.com/eloqdata/rocksdb-cloud.git
-cd rocksdb-cloud
-git checkout main
-LIBNAME=librocksdb-cloud-aws USE_RTTI=1 USE_AWS=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make shared_lib -j8
-LIBNAME=librocksdb-cloud-aws PREFIX=$(pwd)/output make install-shared
-sudo mkdir -p /usr/local/include/rocksdb_cloud_header
-sudo cp -r ./output/include/* /usr/local/include/rocksdb_cloud_header
-sudo cp -r ./output/lib/* /usr/local/lib
-make clean && rm -rf $(pwd)/output
-LIBNAME=librocksdb-cloud-gcp USE_RTTI=1 USE_GCP=1 ROCKSDB_DISABLE_TCMALLOC=1 ROCKSDB_DISABLE_JEMALLOC=1 make shared_lib -j8
-LIBNAME=librocksdb-cloud-gcp PREFIX=$(pwd)/output make install-shared
-sudo cp -r ./output/lib/* /usr/local/lib
-cd ../ && sudo ldconfig && rm -rf rocksdb-cloud
-
-echo "All dependencies have been installed successfully!" 
+  # host_manager adds yaml-cpp from source at product configure time. Retain
+  # manifest-fetched sources so that step remains offline and inside the shared
+  # workspace. Callers may explicitly set this to 0 to recover disk space.
+  ELOQ_THIRD_PARTY_KEEP_SOURCES="${ELOQ_THIRD_PARTY_KEEP_SOURCES:-1}" \
+    taskset --cpu-list "${BUILD_CPU_LIST}" "${THIRD_PARTY_INSTALLER}"
+elif [ ! -f "${THIRD_PARTY_PREFIX}/share/eloq/third-party-manifest.yml" ]; then
+  echo "ELOQ_SKIP_THIRD_PARTY=1, but no completed workspace was found at ${THIRD_PARTY_PREFIX}" >&2
+  exit 1
+fi

--- a/storage/eloq/CMakeLists.txt
+++ b/storage/eloq/CMakeLists.txt
@@ -67,6 +67,7 @@ if(STATISTICS)
 endif()
 
 find_package(MIMALLOC REQUIRED)
+eloq_assert_under_prefix(MIMALLOC_INCLUDE_DIR "mimalloc include directory")
 include_directories(${MIMALLOC_INCLUDE_DIR})
 
 option(SMALL_RANGE "Whether enable small range" OFF)


### PR DESCRIPTION
## Summary

- adopt the Data Substrate third-party workspace used by EloqKV
- pin Data Substrate to the workspace migration revision and use selective product-submodule checkout
- resolve native dependencies, including AWSSDK, from data_substrate/third_party/install
- delegate Ubuntu dependency installation to Data Substrate and cap builds at eight CPU cores
- update Concourse pipelines to stop fetching bundled log-service, host-manager, and EloqStore repositories separately
- make ELOQ_MODULE_ENABLED and EXT_TX_PROC_ENABLED consistent on the first CMake configure pass

## Validation

- configured ELOQDSS_ELOQSTORE with ELOQ_THIRD_PARTY_REQUIRED=ON
- confirmed AWSSDK 1.11.446 resolves from data_substrate/third_party/install
- built the eloq target successfully
- built mariadbd successfully with -j8 after rebasing onto the latest eloq-10.6.10
- ran mariadbd --version and verified no missing runtime libraries
- validated shell syntax, Concourse YAML/resource references, and git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Build & Installation**
  - Simplified checkout and dependency installation workflows.
  - Added support for shared third-party dependencies and improved validation.
  - Build scripts now limit compilation to eight cores and configure runtime library paths automatically.

- **Release Engineering**
  - Streamlined package and nightly build pipelines by removing redundant source inputs.
  - Simplified release branch and tagging workflows.

- **Documentation**
  - Updated build and runtime instructions, including dependency setup and shared-library configuration.

- **Maintenance**
  - Updated the Data Substrate integration and improved compatibility across supported environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->